### PR TITLE
Change source of app name to when running under node

### DIFF
--- a/help/signhelp.js
+++ b/help/signhelp.js
@@ -7,7 +7,7 @@ const content = require('./signcontent');
 
 const getapp = () => {
   const n = process.argv[0].indexOf('node') !== -1;
-  const p = n ? path.resolve() : process.argv[0];
+  const p = n ? process.argv[1] : process.argv[0];
   const name = path.basename(p);
   if (n) return { usage: `node ${name}`, ver: `${name}` };
   const rel = process.argv[0].replace(process.cwd(), process.cwd() === '/' ? '/' : '.');


### PR DESCRIPTION
`node signtxtool help` was displaying staketool in the example commands instead of signtxtool (binary was ok)